### PR TITLE
Update cidr in variable network

### DIFF
--- a/website/docs/language/functions/flatten.mdx
+++ b/website/docs/language/functions/flatten.mdx
@@ -51,34 +51,35 @@ variable "networks" {
       cidr_block = "10.1.0.0/16"
       subnets = {
         "db1" = {
-          cidr_block = "10.1.0.1/16"
+          cidr_block = "10.1.0.0/24"
         }
         "db2" = {
-          cidr_block = "10.1.0.2/16"
+          cidr_block = "10.1.1.0/24"
         }
       }
     },
     "public" = {
-      cidr_block = "10.1.1.0/16"
+      cidr_block = "10.2.0.0/16"
       subnets = {
         "webserver" = {
-          cidr_block = "10.1.1.1/16"
+          cidr_block = "10.2.1.0/24"
         }
         "email_server" = {
-          cidr_block = "10.1.1.2/16"
+          cidr_block = "10.2.2.0/24"
         }
       }
     }
     "dmz" = {
-      cidr_block = "10.1.2.0/16"
+      cidr_block = "10.3.0.0/16"
       subnets = {
         "firewall" = {
-          cidr_block = "10.1.2.1/16"
+          cidr_block = "10.3.1.0/24"
         }
       }
     }
   }
 }
+
 ```
 
 The above is a reasonable way to model objects that naturally form a tree,


### PR DESCRIPTION
i face the following error when run terraform plan: │ Error: expected cidr_block to contain a valid network Value, expected 10.1.0.0/16, got 10.1.2.0/16 │ 
│   with aws_vpc.example["dmz"],
│   on main.tf line 47, in resource "aws_vpc" "example":
│   47:   cidr_block = each.value.cidr_block
│ 
╵
╷
│ Error: expected cidr_block to contain a valid network Value, expected 10.1.0.0/16, got 10.1.1.0/16
│ 
│   with aws_vpc.example["public"],
│   on main.tf line 47, in resource "aws_vpc" "example":
│   47:   cidr_block = each.value.cidr_block

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.13.x

## CHANGELOG entry

<!--

If your change is user-facing, add a short description in a changelog entry.
You can use `npx changie new` to create a new changelog entry or manually create a new file in the .changes/unreleasd directory (or .changes/backported if it's a bug fix that should be backported).

-->

- [ ] This change is user-facing and I added a changelog entry.
- [ ] This change is not user-facing.
